### PR TITLE
Update Makefile for Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ OBJDIR=obj
 INCDIR=include
 
 ifeq ($(SYSTEM),Darwin)
-         FFLAGS +=-I$(shell nf-config --fflags)
+         FFLAGS += $(shell nf-config --fflags)
          LDFLAGS += $(shell nf-config --flibs) \
                     -lnetcdf -lnetcdff
 else


### PR DESCRIPTION
Hubert tells me this doesn't compile on a Mac due to a netCDF issue? It compiled fine on mine with this change. I'm using MacPorts with 

- gcc13 @13.3.0_2+stdlib_flag
- openmpi-gcc13 @5.0.6_1+fortran 
- netcdf-fortran @4.6.1_4+gcc14

DQ