### PR TITLE
Minor fixes and addition of automated testing CI workflows

### DIFF
--- a/.github/workflows/testingOnPush_Apple.yaml
+++ b/.github/workflows/testingOnPush_Apple.yaml
@@ -40,6 +40,18 @@ jobs:
           cd tests
           ../tests.run
     
-      #- name: Run parallel compilation with mpifort
-      #  run: |
-      #    make compiler=mpifort
+      - name: Run parallel compilation with mpifort
+        run: |
+          make compiler=mpifort
+
+      - name: Run tests with mpifort with 1 process
+        run: |
+          make compiler=mpifort tests
+          cd tests
+          mpirun -np 1 ../tests.run
+
+      - name: Run tests with mpifort with 4 processes
+        run: |
+          make compiler=mpifort tests
+          cd tests
+          mpirun -np 4 ../tests.run

--- a/.github/workflows/testingOnPush_Apple.yaml
+++ b/.github/workflows/testingOnPush_Apple.yaml
@@ -1,0 +1,43 @@
+name: MacOS (M1)
+
+on:
+  push:
+    paths:
+      - 'tests/**'
+      - 'src/**'
+      - '.github/workflows/testingOnPush_Apple.yaml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install gfortran and other dependencies with Homebrew
+        run: brew install gcc make pkg-config openblas netcdf netcdf-fortran open-mpi
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run serial compilation with gfortran
+        run: |
+          make compiler=gfortran
+
+      - name: Run tests with gfortran
+        run: |
+          make compiler=gfortran tests     
+          cd tests
+          ../tests.run
+    
+      #- name: Run parallel compilation with mpifort
+      #  run: |
+      #    make compiler=mpifort

--- a/.github/workflows/testingOnPush_Apple.yaml
+++ b/.github/workflows/testingOnPush_Apple.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'tests/**'
       - 'src/**'
+      - 'Makefile'
+      - 'requirements.txt'
       - '.github/workflows/testingOnPush_Apple.yaml'
   workflow_dispatch:
 
@@ -16,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install gfortran and other dependencies with Homebrew
-        run: brew install gcc make pkg-config openblas netcdf netcdf-fortran open-mpi
+        run: brew install gcc make openblas netcdf netcdf-fortran open-mpi
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/testingOnPush_Ubuntu.yaml
+++ b/.github/workflows/testingOnPush_Ubuntu.yaml
@@ -40,6 +40,18 @@ jobs:
           cd tests
           ../tests.run
     
-      #- name: Run parallel compilation with mpifort
-      #  run: |
-      #    make compiler=mpifort
+      - name: Run parallel compilation with mpifort
+        run: |
+          make compiler=mpifort
+
+      - name: Run tests with mpifort with 1 process
+        run: |
+          make compiler=mpifort tests
+          cd tests
+          mpirun -np 1 ../tests.run
+
+      - name: Run tests with mpifort with 4 processes
+        run: |
+          make compiler=mpifort tests
+          cd tests
+          mpirun -np 4 ../tests.run

--- a/.github/workflows/testingOnPush_Ubuntu.yaml
+++ b/.github/workflows/testingOnPush_Ubuntu.yaml
@@ -1,0 +1,45 @@
+name: Ubuntu (x86_64)
+
+on:
+  push:
+    paths:
+      - 'tests/**'
+      - 'src/**'
+      - 'Makefile'
+      - 'requirements.txt'
+      - '.github/workflows/testingOnPush_Ubuntu.yaml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install gfortran and other dependencies with apt
+        run: sudo apt-get install -y gfortran make libopenblas-dev libnetcdf-dev libnetcdf-fortran-dev mpich
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run serial compilation with gfortran
+        run: |
+          make compiler=gfortran
+
+      - name: Run tests with gfortran
+        run: |
+          make compiler=gfortran tests     
+          cd tests
+          ../tests.run
+    
+      #- name: Run parallel compilation with mpifort
+      #  run: |
+      #    make compiler=mpifort

--- a/.github/workflows/testingOnPush_Ubuntu.yaml
+++ b/.github/workflows/testingOnPush_Ubuntu.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install gfortran and other dependencies with apt
-        run: sudo apt-get install -y gfortran make libopenblas-dev libnetcdf-dev libnetcdf-fortran-dev mpich
+        run: sudo apt-get install -y gfortran make libopenblas-dev libnetcdf-dev libnetcdff-dev mpich
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ INCDIR=include
 ifeq ($(SYSTEM),Darwin)
          FFLAGS += $(shell nf-config --fflags)
          LDFLAGS += $(shell nf-config --flibs) \
-					$(shell nc-config --libs)
-                    -lnetcdf -lnetcdff
+					$(shell nc-config --libs) \
+					-lnetcdf -lnetcdff
 else
          FFLAGS +=$(shell nf-config --fflags)
          LDFLAGS += $(shell nf-config --flibs) \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # BraWl
 
+[![MacOS (M1)](https://github.com/ChrisWoodgate/BraWl/actions/workflows/testingOnPush_Apple.yaml/badge.svg)](https://github.com/ChrisWoodgate/BraWl/actions/workflows/testingOnPush_Apple.yaml)
+[![Ubuntu (x86_64)](https://github.com/ChrisWoodgate/BraWl/actions/workflows/testingOnPush_Ubuntu.yaml/badge.svg)](https://github.com/ChrisWoodgate/BraWl/actions/workflows/testingOnPush_Ubuntu.yaml)
+[![License: MIT](https://img.shields.io/badge/License-LGPLv3-yellow.svg)](https://opensource.org/license/lgpl-3-0)
+
 `BraWl` — a package for performing lattice-based atomistic simulations of alloys with an internal energy given by a Bragg-Williams Hamiltonian. The package implements a range of conventional and enhanced sampling techniques, including Metropolis-Hastings Monte Carlo, Nested Sampling, and Wang-Landau sampling.
 
 Copyright (C) The Authors 2019-2025. Released under the GNU Lesser General Public License, version 3.

--- a/src/io.f90
+++ b/src/io.f90
@@ -89,7 +89,7 @@ module io
       write(6,'(72("-"))')
       ! Start the clock
       call cpu_time(t_stop)
-      write(6,'(20x,"Execution time",1x,f9.1 " seconds")') t_stop-t_start
+      write(6,'(20x,"Execution time",1x,f9.1,1x," seconds")') t_stop-t_start
     endif
 
     write(6,'(72("="),/)' )

--- a/src/metropolis.F90
+++ b/src/metropolis.F90
@@ -375,7 +375,7 @@ module metropolis
 
       ! Dump grids as xyz files if needed
       if (metropolis%write_final_config_xyz) then
-          write(xyz_file, '(A11 I4.4 A12 I4.4 F2.1 A4)') 'configs/proc_', &
+          write(xyz_file, '(A13,I4.4,A12,I4.4,F2.1,A4)') 'configs/proc_', &
           my_rank, '_config_at_T_', int(temp), temp-int(temp),'.xyz'
 
           ! Write xyz file
@@ -384,7 +384,7 @@ module metropolis
   
       ! Dump grids as NetCDF files if needed
       if (metropolis%write_final_config_nc) then
-        write(grid_file, '(A11 I4.4 A11 I4.4 F2.1 A3)') 'configs/proc_', my_rank, '_grid_at_T_', &
+        write(grid_file, '(A13,I4.4,A11,I4.4,F2.1,A3)') 'configs/proc_', my_rank, '_grid_at_T_', &
                                              int(temp), temp-int(temp), '.nc'
         ! Write grid to file
         call ncdf_grid_state_writer(trim(grid_file), ierr, config, setup)
@@ -414,14 +414,14 @@ module metropolis
     ! Write energy diagnostics
     if (metropolis%calculate_energies) then
       write(diagnostics_file, '(A,I4.4,A)') 'energies/proc_', my_rank, &
-                                           'energy_diagnostics.dat'
+                                           '_energy_diagnostics.dat'
       call diagnostics_writer(trim(diagnostics_file), temperature, &
                               energies_of_T, C_of_T, acceptance_of_T)
     end if
 
     ! Write radial densities
     if (metropolis%calculate_asro) then
-      write(radial_file, '(A,I3.3,A)') 'asro/proc_', my_rank, '_rho_of_T.nc'
+      write(radial_file, '(A,I4.4,A)') 'asro/proc_', my_rank, '_rho_of_T.nc'
       ! Write the radial densities to file
       call ncdf_radial_density_writer(trim(radial_file), rho_of_T, &
                                       shells, temperature, energies_of_T, setup)
@@ -429,7 +429,7 @@ module metropolis
 
     ! Write radial densities
     if (metropolis%calculate_alro) then
-      write(alro_file, '(A22 I3.3 A12)') 'alro/proc_', my_rank, '_rho_of_T.nc'
+      write(alro_file, '(A22,I4.4,A12)') 'alro/proc_', my_rank, '_rho_of_T.nc'
       ! Write the radial densities to file
       call ncdf_order_writer(trim(alro_file), ierr, order_of_T, temperature, setup)
     end if
@@ -605,7 +605,7 @@ module metropolis
           ! Get the energy of this configuration
           current_energy = setup%full_energy(config)
 
-          write(xyz_file, '(A11 I3.3 A8 I4.4 A6 I4.4 F2.1 A4)') &
+          write(xyz_file, '(A,I4.4,A8,I4.4,A6,I4.4,F2.1,A4)') &
           'configs/proc_', my_rank, '_config_',                   &
           int(i/metropolis%n_sample_steps_asro), '_at_T_', int(temp),&
           temp-int(temp),'.xyz'


### PR DESCRIPTION
This PR:
- Adjusts a couple of lines to (a) compile with v15.x of `gcc` and (b) fix truncation of a couple of output file names, per comments in #54. 
- Adds CI automated testing over macOS and Linux, running tests in serial, parallel (single-thread), and parallel (multi-thread) fashion per suggestion from #52. The (failed) results of parallel tests on macOS due to MPI inability to find `openblas`, while the serial compilation has no such issues, replicates the problem with parallel version compilation raised in #54. 
- Adds live test badges to the `README`. They already point to `ChrisWoodgate/BraWl` so they will be empty until PR is accepted and workflows are allowed to run. Also adds the license badge.